### PR TITLE
Remove EODHD news and economic events, simplify news API

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -117,17 +117,17 @@ export default function Index() {
             setMarketauxError(null);
           }
         } else {
-          console.warn("Marketaux API returned non-JSON content:", contentType);
+          console.warn("News API returned non-JSON content:", contentType);
           setMarketauxError("Invalid response format");
           setMarketauxNews([]);
         }
       } else {
-        console.warn("Marketaux API returned non-OK status:", response.status);
+        console.warn("News API returned non-OK status:", response.status);
         setMarketauxError(`API Error: ${response.status}`);
         setMarketauxNews([]);
       }
     } catch (error) {
-      console.error("Failed to fetch Marketaux news:", error);
+      console.error("Failed to fetch news:", error);
       setMarketauxError("Failed to fetch financial news");
       setMarketauxNews([]);
     } finally {

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -308,8 +308,8 @@ export default function Index() {
                   </CardTitle>
                   <CardDescription>
                     {language === "ar"
-                      ? "آخر الأخبار المالية والاقتصادية من Marketaux"
-                      : "Latest financial and economic news from Marketaux"}
+                      ? "آخر الأخبار المالية والاقتصادية"
+                      : "Latest financial and economic news"}
                   </CardDescription>
                 </CardHeader>
                 <CardContent>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -439,41 +439,6 @@ export default function Index() {
                 </CardContent>
               </Card>
 
-              {/* Traditional EODHD Economic Events */}
-              <Card className="mb-8">
-                <CardHeader>
-                  <CardTitle className="flex items-center gap-2">
-                    <Calendar className="w-5 h-5 text-primary" />
-                    {language === "ar"
-                      ? "التقويم الاقتصادي التقليدي"
-                      : "Traditional Economic Calendar"}
-                  </CardTitle>
-                  <CardDescription>
-                    {language === "ar"
-                      ? "أحداث اقتصادية مهمة ومؤشرات مالية رئيسية"
-                      : "Important economic events and key financial indicators"}
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  {isLoadingEvents ? (
-                    <div className="flex items-center justify-center py-12">
-                      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
-                      <span className="ml-2">
-                        {language === "ar"
-                          ? "جاري تحميل الأحداث الاقتصادية..."
-                          : "Loading economic events..."}
-                      </span>
-                    </div>
-                  ) : (
-                    <MacroCalendarTable
-                      events={economicEvents}
-                      className="rounded-lg overflow-hidden"
-                      language={language}
-                      dir={dir}
-                    />
-                  )}
-                </CardContent>
-              </Card>
 
               {/* Traditional News Cards */}
               <Card>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -15,10 +15,7 @@ import TradingViewTicker from "@/components/ui/trading-view-ticker";
 import { AIEventInsight } from "@/components/ui/ai-event-insight";
 import { ChatWidget } from "@/components/ui/chat-widget";
 import { MacroCalendarTable } from "@/components/ui/macro-calendar-table";
-import {
-  MarketauxNewsResponse,
-  MarketauxNewsItem,
-} from "@shared/api";
+import { MarketauxNewsResponse, MarketauxNewsItem } from "@shared/api";
 import { AdvancedAlertSystem } from "@/components/ui/advanced-alert-system";
 import { NotificationSystem } from "@/components/ui/notification-system";
 import { NotificationDropdown } from "@/components/ui/notification-dropdown";
@@ -352,8 +349,6 @@ export default function Index() {
                   )}
                 </CardContent>
               </Card>
-
-
             </div>
           </section>
 

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -136,84 +136,8 @@ export default function Index() {
     }
   };
 
-  // Fetch EODHD data with enhanced error handling and fallback
+  // Fetch Marketaux news data on component mount
   useEffect(() => {
-    const fetchEconomicEvents = async () => {
-      try {
-        setIsLoadingEvents(true);
-        // Add timeout to prevent hanging
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), 10000); // 10 second timeout
-
-        const response = await fetch("/api/economic-events", {
-          signal: controller.signal,
-        });
-        clearTimeout(timeoutId);
-
-        if (response.ok) {
-          // Check if response is JSON before parsing
-          const contentType = response.headers.get("content-type");
-          if (contentType && contentType.includes("application/json")) {
-            const data: EconomicEventsResponse = await response.json();
-            setEconomicEvents(data.events || []);
-          } else {
-            console.warn(
-              "Economic events API returned non-JSON content:",
-              contentType,
-            );
-            setEconomicEvents([]);
-          }
-        } else {
-          console.warn(
-            "Economic events API returned non-OK status:",
-            response.status,
-          );
-          setEconomicEvents([]); // Set empty array on failure
-        }
-      } catch (error) {
-        console.error("Failed to fetch economic events:", error);
-        setEconomicEvents([]); // Always set fallback data
-      } finally {
-        setIsLoadingEvents(false);
-      }
-    };
-
-    const fetchNews = async () => {
-      try {
-        setIsLoadingNews(true);
-        // Add timeout to prevent hanging
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), 10000); // 10 second timeout
-
-        const response = await fetch("/api/news", {
-          signal: controller.signal,
-        });
-        clearTimeout(timeoutId);
-
-        if (response.ok) {
-          // Check if response is JSON before parsing
-          const contentType = response.headers.get("content-type");
-          if (contentType && contentType.includes("application/json")) {
-            const data: NewsResponse = await response.json();
-            setNews(data.news || []);
-          } else {
-            console.warn("News API returned non-JSON content:", contentType);
-            setNews([]);
-          }
-        } else {
-          console.warn("News API returned non-OK status:", response.status);
-          setNews([]); // Set empty array on failure
-        }
-      } catch (error) {
-        console.error("Failed to fetch news:", error);
-        setNews([]); // Always set fallback data
-      } finally {
-        setIsLoadingNews(false);
-      }
-    };
-
-    fetchEconomicEvents();
-    fetchNews();
     fetchMarketauxNews();
   }, []);
 

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -48,7 +48,7 @@ export default function Index() {
   const [name, setName] = useState("");
   const [whatsapp, setWhatsapp] = useState("");
 
-  // Marketaux News Data State
+  // News Data State
   const [marketauxNews, setMarketauxNews] = useState<MarketauxNewsItem[]>([]);
   const [isLoadingMarketaux, setIsLoadingMarketaux] = useState(true);
   const [marketauxError, setMarketauxError] = useState<string | null>(null);

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -108,7 +108,7 @@ export default function Index() {
       const timeoutId = setTimeout(() => controller.abort(), 15000); // 15 second timeout
 
       const response = await fetch(
-        `/api/marketaux-news?language=${lang}&limit=50`,
+        `/api/marketaux-news?language=${lang}&limit=3&countries=us,gb,ae`,
         {
           signal: controller.signal,
         },

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -17,8 +17,6 @@ import { ChatWidget } from "@/components/ui/chat-widget";
 import { MacroCalendarTable } from "@/components/ui/macro-calendar-table";
 import { NewsCardsList } from "@/components/ui/news-cards-list";
 import {
-  EconomicEventsResponse,
-  NewsResponse,
   MarketauxNewsResponse,
   MarketauxNewsItem,
 } from "@shared/api";

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -49,17 +49,10 @@ export default function Index() {
   const [name, setName] = useState("");
   const [whatsapp, setWhatsapp] = useState("");
 
-  // EODHD Data State
-  const [economicEvents, setEconomicEvents] = useState<
-    EconomicEventsResponse["events"]
-  >([]);
   // Marketaux News Data State
   const [marketauxNews, setMarketauxNews] = useState<MarketauxNewsItem[]>([]);
   const [isLoadingMarketaux, setIsLoadingMarketaux] = useState(true);
   const [marketauxError, setMarketauxError] = useState<string | null>(null);
-  const [news, setNews] = useState<NewsResponse["news"]>([]);
-  const [isLoadingEvents, setIsLoadingEvents] = useState(true);
-  const [isLoadingNews, setIsLoadingNews] = useState(true);
   const [isNavbarVisible, setIsNavbarVisible] = useState(true);
   const [lastScrollY, setLastScrollY] = useState(0);
 

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -88,7 +88,7 @@ export default function Index() {
     return () => window.removeEventListener("scroll", handleScroll);
   }, [lastScrollY]);
 
-  // Fetch Marketaux news data with language support
+  // Fetch news data with language support
   const fetchMarketauxNews = async (lang: string = language) => {
     try {
       setIsLoadingMarketaux(true);

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -15,7 +15,6 @@ import TradingViewTicker from "@/components/ui/trading-view-ticker";
 import { AIEventInsight } from "@/components/ui/ai-event-insight";
 import { ChatWidget } from "@/components/ui/chat-widget";
 import { MacroCalendarTable } from "@/components/ui/macro-calendar-table";
-import { NewsCardsList } from "@/components/ui/news-cards-list";
 import {
   MarketauxNewsResponse,
   MarketauxNewsItem,

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -135,12 +135,12 @@ export default function Index() {
     }
   };
 
-  // Fetch Marketaux news data on component mount
+  // Fetch news data on component mount
   useEffect(() => {
     fetchMarketauxNews();
   }, []);
 
-  // Fetch Marketaux news when language changes
+  // Fetch news when language changes
   useEffect(() => {
     fetchMarketauxNews(language);
   }, [language]);

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -440,37 +440,6 @@ export default function Index() {
               </Card>
 
 
-              {/* Traditional News Cards */}
-              <Card>
-                <CardHeader>
-                  <CardTitle className="flex items-center gap-2">
-                    <TrendingUp className="w-5 h-5 text-primary" />
-                    {language === "ar" ? "أخبار EODHD" : "EODHD News"}
-                  </CardTitle>
-                  <CardDescription>
-                    {language === "ar"
-                      ? "آخر الأخبار والتحليلات المالية التقليدية"
-                      : "Traditional financial news and market analysis"}
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  {isLoadingNews ? (
-                    <div className="flex items-center justify-center py-12">
-                      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
-                      <span className="ml-2">
-                        {language === "ar"
-                          ? "جاري تحميل الأخبار..."
-                          : "Loading news..."}
-                      </span>
-                    </div>
-                  ) : (
-                    <NewsCardsList
-                      news={news}
-                      className="max-h-[600px] overflow-y-auto"
-                    />
-                  )}
-                </CardContent>
-              </Card>
             </div>
           </section>
 

--- a/server/routes/marketaux-news.ts
+++ b/server/routes/marketaux-news.ts
@@ -78,7 +78,7 @@ export const handleMarketauxNews: RequestHandler = async (req, res) => {
           forecast: item.forecast || null,
           previous: item.previous || null,
           url: item.url || "",
-          source: item.source || "Marketaux",
+          source: "Liirat",
           sentiment: item.sentiment || null,
           entities: item.entities || [],
         };

--- a/server/routes/marketaux-news.ts
+++ b/server/routes/marketaux-news.ts
@@ -19,18 +19,11 @@ export const handleMarketauxNews: RequestHandler = async (req, res) => {
       });
     }
 
-    // Calculate published_after date (last 7 days)
-    const publishedAfter = new Date();
-    publishedAfter.setDate(publishedAfter.getDate() - 7);
-    const publishedAfterISO = publishedAfter.toISOString();
-
-    // Build API URL
+    // Build API URL according to specifications
     const apiUrl = new URL("https://api.marketaux.com/v1/news/all");
     apiUrl.searchParams.append("countries", countries as string);
-    apiUrl.searchParams.append("filter_entities", "true");
-    apiUrl.searchParams.append("limit", limit as string);
-    apiUrl.searchParams.append("published_after", publishedAfterISO);
     apiUrl.searchParams.append("language", language as string);
+    apiUrl.searchParams.append("limit", limit as string);
     apiUrl.searchParams.append("api_token", apiKey);
 
     console.log(`Fetching Marketaux news for language: ${language}`);

--- a/server/routes/marketaux-news.ts
+++ b/server/routes/marketaux-news.ts
@@ -93,7 +93,7 @@ export const handleMarketauxNews: RequestHandler = async (req, res) => {
 
     res.json(response_data);
   } catch (error) {
-    console.error("Error fetching Marketaux news:", error);
+    console.error("Error fetching news:", error);
     res.status(500).json({
       error: "Failed to fetch financial news",
       news: [],

--- a/server/routes/marketaux-news.ts
+++ b/server/routes/marketaux-news.ts
@@ -39,7 +39,7 @@ export const handleMarketauxNews: RequestHandler = async (req, res) => {
 
     if (!response.ok) {
       console.error(
-        `Marketaux API error: ${response.status} - ${response.statusText}`,
+        `News API error: ${response.status} - ${response.statusText}`,
       );
       return res.status(response.status).json({
         error: `API request failed: ${response.statusText}`,

--- a/server/routes/marketaux-news.ts
+++ b/server/routes/marketaux-news.ts
@@ -5,8 +5,8 @@ export const handleMarketauxNews: RequestHandler = async (req, res) => {
   try {
     const {
       language = "en",
-      countries = "US,GB,EU,JP,CA,AU,DE,FR",
-      limit = 20,
+      countries = "us,gb,ae",
+      limit = "3",
     } = req.query;
 
     // Get API key from environment variable

--- a/server/routes/marketaux-news.ts
+++ b/server/routes/marketaux-news.ts
@@ -3,11 +3,7 @@ import { MarketauxNewsResponse } from "@shared/api";
 
 export const handleMarketauxNews: RequestHandler = async (req, res) => {
   try {
-    const {
-      language = "en",
-      countries = "us,gb,ae",
-      limit = "3",
-    } = req.query;
+    const { language = "en", countries = "us,gb,ae", limit = "3" } = req.query;
 
     // Get API key from environment variable
     const apiKey = process.env.MARKETAUX_API_KEY;

--- a/server/routes/marketaux-news.ts
+++ b/server/routes/marketaux-news.ts
@@ -26,7 +26,7 @@ export const handleMarketauxNews: RequestHandler = async (req, res) => {
     apiUrl.searchParams.append("limit", limit as string);
     apiUrl.searchParams.append("api_token", apiKey);
 
-    console.log(`Fetching Marketaux news for language: ${language}`);
+    console.log(`Fetching news for language: ${language}`);
 
     // Fetch data from Marketaux API
     const response = await fetch(apiUrl.toString(), {


### PR DESCRIPTION
## Changes Made

### Frontend (client/pages/Index.tsx)
- **Removed imports**: Eliminated unused imports for `NewsCardsList`, `EconomicEventsResponse`, and `NewsResponse`
- **Simplified state management**: 
  - Removed `economicEvents`, `news`, `isLoadingEvents`, and `isLoadingNews` state variables
  - Kept only Marketaux news-related state
- **Removed API calls**: Eliminated `fetchEconomicEvents` and `fetchNews` functions
- **Updated comments**: Changed references from "Marketaux" to generic "news" terminology
- **Removed UI components**:
  - Removed Traditional Economic Calendar card section
  - Removed EODHD News card section
- **Updated news card description**: Simplified from "Latest financial and economic news from Marketaux" to "Latest financial and economic news"

### Backend (server/routes/marketaux-news.ts)
- **Simplified query parameters**: Changed default countries from "US,GB,EU,JP,CA,AU,DE,FR" to "us,gb,ae" and limit from 20 to 3
- **Removed API filters**: 
  - Removed `filter_entities` parameter
  - Removed `published_after` date filtering (7-day limit)
- **Updated source attribution**: Changed news source from "Marketaux" to "Liirat"
- **Updated logging**: Changed console messages from "Marketaux" references to generic "news"

## Summary
This pull request streamlines the news functionality by removing EODHD-based components and focusing solely on Marketaux news with simplified parameters and reduced data volume.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 20`

🔗 [Edit in Builder.io](https://builder.io/app/projects/375c865c848548628571acba9ff90110/aura-hub)

👀 [Preview Link](https://375c865c848548628571acba9ff90110-aura-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>375c865c848548628571acba9ff90110</projectId>-->
<!--<branchName>aura-hub</branchName>-->